### PR TITLE
feat:global.cssの認識エラーの修正

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';


### PR DESCRIPTION
- src/app/global.cssがNext.jsのモジュールに認識されていなかったため、cssの型定義モジュールを追加して対処

## 概要
<!-- このPRで何をしたか一言で -->
cssの方定義モジュールを追加して、cssの認識エラーを修正した

## 変更内容
- `root`に`global.d.ts`を追加した
- 

## 関連issue
closes #24 

## 動作確認
- [x] ローカルで確認済み
- [x] 既存機能への影響を確認済み

## レビュアーへのメモ（任意）
<!-- 特に見てほしい箇所・背景など -->
