### PR TITLE
feat: blueprintデザインシステムの基盤を追加

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -48,6 +48,16 @@
     --radius-2xl: calc(var(--radius) * 1.8);
     --radius-3xl: calc(var(--radius) * 2.2);
     --radius-4xl: calc(var(--radius) * 2.6);
+    /* Blueprint design system tokens */
+    --color-bp-bg: var(--bp-bg);
+    --color-bp-bg-deep: var(--bp-bg-deep);
+    --color-bp-ink: var(--bp-ink);
+    --color-bp-ink-soft: var(--bp-ink-soft);
+    --color-bp-ink-dim: var(--bp-ink-dim);
+    --color-bp-paper: var(--bp-paper);
+    --color-bp-accent: var(--bp-accent);
+    --color-bp-rule: var(--bp-rule);
+    --font-mono: var(--font-geist-mono), ui-monospace, monospace;
 }
 
 :root {
@@ -123,24 +133,73 @@
     --sidebar-ring: oklch(0.556 0 0);
 }
 
+/* Blueprint theme CSS variable definitions */
+/* next-themes writes drafting/blueprint/vellum to <html class="..."> → CSS picks up the right vars */
+
+:root, .drafting {
+    --bp-bg: oklch(26.033% 0.00003 271.152);
+    --bp-bg-deep: oklch(20% 0.00003 271.152);
+    --bp-ink: oklch(0.95 0 0);
+    --bp-ink-soft: oklch(0.78 0 0);
+    --bp-ink-dim: oklch(0.55 0 0);
+    --bp-paper: oklch(30% 0.00003 271.152 / 0.6);
+    --bp-accent: #7ee787;
+    --bp-rule: oklch(95% 0 0 / 0.22);
+}
+
+.blueprint {
+    --bp-bg: #0e3a64;
+    --bp-bg-deep: #092d51;
+    --bp-ink: #e9f3ff;
+    --bp-ink-soft: #b8d4f0;
+    --bp-ink-dim: #7aa8d0;
+    --bp-paper: rgba(14, 58, 100, 0.6);
+    --bp-accent: #fff8d6;
+    --bp-rule: rgba(233, 243, 255, 0.22);
+}
+
+.vellum {
+    --bp-bg: #f1ead6;
+    --bp-bg-deep: #e8dfc4;
+    --bp-ink: #1a1a1a;
+    --bp-ink-soft: #3a3a3a;
+    --bp-ink-dim: #6a6a6a;
+    --bp-paper: rgba(241, 234, 214, 0.8);
+    --bp-accent: #c2410c;
+    --bp-rule: rgba(26, 26, 26, 0.2);
+}
+
 @layer base {
     * {
         @apply border-border outline-ring/50;
     }
     body {
-        @apply bg-background text-foreground;
+        background-color: var(--bp-bg);
+        color: var(--bp-ink);
     }
     html {
         @apply font-sans;
     }
 }
-.grid-bg-dark {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cline x1='0' y1='0' x2='160' y2='0' stroke='white' stroke-opacity='0.2' stroke-width='1'/%3E%3Cline x1='0' y1='0' x2='0' y2='160' stroke='white' stroke-opacity='0.2' stroke-width='1'/%3E%3C/svg%3E");
-    background-size: 160px 160px;
-    background-repeat: repeat;
+
+/* Grid background: 80px major + 16px minor — per theme (CSS vars can't be used inside SVG data:URI) */
+html body, html.drafting body {
+    background-image:
+        url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='80' height='80'%3E%3Cline x1='0' y1='0' x2='80' y2='0' stroke='rgba(255,255,255,0.22)' stroke-width='1'/%3E%3Cline x1='0' y1='0' x2='0' y2='80' stroke='rgba(255,255,255,0.22)' stroke-width='1'/%3E%3C/svg%3E"),
+        url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cline x1='0' y1='0' x2='16' y2='0' stroke='rgba(255,255,255,0.10)' stroke-width='0.5'/%3E%3Cline x1='0' y1='0' x2='0' y2='16' stroke='rgba(255,255,255,0.10)' stroke-width='0.5'/%3E%3C/svg%3E");
+    background-size: 80px 80px, 16px 16px;
 }
-.grid-bg-light {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cline x1='0' y1='0' x2='160' y2='0' stroke='white' stroke-opacity='0.2' stroke-width='1'/%3E%3Cline x1='0' y1='0' x2='0' y2='160' stroke='white' stroke-opacity='0.2' stroke-width='1'/%3E%3C/svg%3E");
-    background-size: 160px 160px;
-    background-repeat: repeat;
+
+html.blueprint body {
+    background-image:
+        url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='80' height='80'%3E%3Cline x1='0' y1='0' x2='80' y2='0' stroke='rgba(180,215,255,0.32)' stroke-width='1'/%3E%3Cline x1='0' y1='0' x2='0' y2='80' stroke='rgba(180,215,255,0.32)' stroke-width='1'/%3E%3C/svg%3E"),
+        url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cline x1='0' y1='0' x2='16' y2='0' stroke='rgba(180,215,255,0.18)' stroke-width='0.5'/%3E%3Cline x1='0' y1='0' x2='0' y2='16' stroke='rgba(180,215,255,0.18)' stroke-width='0.5'/%3E%3C/svg%3E");
+    background-size: 80px 80px, 16px 16px;
+}
+
+html.vellum body {
+    background-image:
+        url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='80' height='80'%3E%3Cline x1='0' y1='0' x2='80' y2='0' stroke='rgba(0,0,0,0.22)' stroke-width='1'/%3E%3Cline x1='0' y1='0' x2='0' y2='80' stroke='rgba(0,0,0,0.22)' stroke-width='1'/%3E%3C/svg%3E"),
+        url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cline x1='0' y1='0' x2='16' y2='0' stroke='rgba(0,0,0,0.12)' stroke-width='0.5'/%3E%3Cline x1='0' y1='0' x2='0' y2='16' stroke='rgba(0,0,0,0.12)' stroke-width='0.5'/%3E%3C/svg%3E");
+    background-size: 80px 80px, 16px 16px;
 }

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -3,9 +3,15 @@
 import * as React from "react";
 import { ThemeProvider as NextThemesProvider } from "next-themes";
 
-export function ThemeProvider({
-    children,
-    ...props
-}: React.ComponentProps<typeof NextThemesProvider>) {
-    return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+    return (
+        <NextThemesProvider
+            attribute="class"
+            defaultTheme="drafting"
+            themes={["drafting", "blueprint", "vellum"]}
+            disableTransitionOnChange
+        >
+            {children}
+        </NextThemesProvider>
+    );
 }

--- a/src/lib/post.ts
+++ b/src/lib/post.ts
@@ -41,8 +41,19 @@ export const getAllPosts = async (): Promise<PostData[]> => {
     return await Promise.all(postContents);
 };
 
-// tagを受け取って、そのtagがついた記事のPostData[]を返す関数
 export const getPostsByTag = async (tag: string): Promise<PostData[]> => {
-    throw new Error("not implemeted");
+    const posts = await getAllPosts();
+    return posts.filter((post) => post.tag.includes(tag));
+};
+
+export const getAllTagsWithCounts = async (): Promise<Map<string, number>> => {
+    const posts = await getAllPosts();
+    const counts = new Map<string, number>();
+    posts.forEach((post) => {
+        post.tag.forEach((tag) => {
+            counts.set(tag, (counts.get(tag) ?? 0) + 1);
+        });
+    });
+    return counts;
 };
 export default getPostData;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,17 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function calcReadingTime(content: string): number {
+  const words = content.trim().split(/\s+/).length;
+  return Math.max(1, Math.ceil(words / 200));
+}
+
+export function getExcerpt(content: string, maxLength = 100): string {
+  const plain = content
+    .replace(/```[\s\S]*?```/g, "")
+    .replace(/[#*`\[\]()_~>|]/g, "")
+    .replace(/\n+/g, " ")
+    .trim();
+  return plain.length > maxLength ? plain.slice(0, maxLength) + "…" : plain;
+}


### PR DESCRIPTION
## Summary

- `globals.css` に `--bp-*` CSS変数（bp-bg / bp-ink / bp-accent / bp-rule 等）と3テーマ（drafting / blueprint / vellum）のクラス、SVGグリッド背景を追加
- `theme-provider.tsx` を3テーマ対応（defaultTheme="drafting"）に更新
- `lib/post.ts` に `getAllTagsWithCounts(): Promise<Map<string, number>>` を追加
- `lib/utils.ts` に `calcReadingTime()` / `getExcerpt()` を追加

## Test plan

- [ ] `pnpm dev` でアプリが起動する
- [ ] `pnpm build` が TypeScript エラーなしで通る
- [ ] 次ブランチ（feat/blueprint-layout）の前提として、CSS変数・ユーティリティ関数が揃っている

🤖 Generated with [Claude Code](https://claude.ai/claude-code)