### PR TITLE
Feature/フォント配色設定

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,6 +5,13 @@
 @custom-variant dark (&:is(.dark *));
 @plugin "@tailwindcss/typography";
 
+body{
+    background-image:
+        linear-gradient(to right,var(--grid-line) 1px,transparent 1px),
+        linear-gradient(to bottom ,var(--grid-line) 1px,transparent 1px);
+    background-size: 160px 160px;
+}
+
 @theme inline {
     --font-heading: var(--font-sans);
     --font-sans: var(--font-sans);
@@ -51,11 +58,12 @@
 }
 
 :root {
-    --background: oklch(94% 0.005 265);
+    --background: #f1ead6;
     --foreground: oklch(0.145 0 0);
-    --vivid: oklch(52% 0.22 260);
-    --vivid-end: oklch(58% 0.2 300);
-    --card: oklch(97% 0.008 260 / 0.65);
+    --grid-line: oklch(0 0 0 / 0.07);
+    --vivid: oklch(50% 0.19 38);
+    --vivid-end: oklch(56% 0.18 50);
+    --card: rgba(255, 255, 255, 0.4);
     --card-foreground: oklch(0.145 0 0);
     --popover: oklch(1 0 0);
     --popover-foreground: oklch(0.145 0 0);
@@ -68,7 +76,7 @@
     --accent: oklch(0.97 0 0);
     --accent-foreground: oklch(0.205 0 0);
     --destructive: oklch(0.577 0.245 27.325);
-    --border: oklch(74% 0.018 260 / 0.45);
+    --border: rgba(0, 0, 0, 0.22);
     --input: oklch(0.922 0 0);
     --ring: oklch(0.708 0 0);
     --chart-1: oklch(0.87 0 0);
@@ -90,8 +98,9 @@
 .dark {
     --background: oklch(26.033% 0.00003 271.152);
     --foreground: oklch(0.91 0 0);
-    --vivid: oklch(68% 0.18 260);
-    --vivid-end: oklch(72% 0.16 300);
+    --grid-line: oklch(1 0 0 / 0.08);
+    --vivid: #7ee787;
+    --vivid-end: #a8f0b4;
     --card: oklch(38.666% 0.00004 271.152 / 0.304);
     --card-foreground: oklch(0.985 0 0 / 0.7);
     --popover: oklch(0.205 0 0);
@@ -105,7 +114,7 @@
     --accent: oklch(0.269 0 0);
     --accent-foreground: oklch(0.985 0 0);
     --destructive: oklch(0.704 0.191 22.216);
-    --border: oklch(94.611% 0.00011 271.152 / 0.634);
+    --border: rgba(223, 223, 223, 0.5);
     --input: oklch(1 0 0 / 15%);
     --ring: oklch(0.556 0 0);
     --chart-1: oklch(0.87 0 0);
@@ -133,14 +142,4 @@
     html {
         @apply font-sans;
     }
-}
-.grid-bg-dark {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cline x1='0' y1='0' x2='160' y2='0' stroke='white' stroke-opacity='0.2' stroke-width='1'/%3E%3Cline x1='0' y1='0' x2='0' y2='160' stroke='white' stroke-opacity='0.2' stroke-width='1'/%3E%3C/svg%3E");
-    background-size: 160px 160px;
-    background-repeat: repeat;
-}
-.grid-bg-light {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cline x1='0' y1='0' x2='160' y2='0' stroke='white' stroke-opacity='0.2' stroke-width='1'/%3E%3Cline x1='0' y1='0' x2='0' y2='160' stroke='white' stroke-opacity='0.2' stroke-width='1'/%3E%3C/svg%3E");
-    background-size: 160px 160px;
-    background-repeat: repeat;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -58,7 +58,7 @@ body{
 }
 
 :root {
-    --background: #f1ead6;
+    --background: oklch(93.7% 0.0275 90.9);
     --foreground: oklch(0.145 0 0);
     --grid-line: oklch(0 0 0 / 0.07);
     --vivid: oklch(50% 0.19 38);
@@ -99,8 +99,8 @@ body{
     --background: oklch(26.033% 0.00003 271.152);
     --foreground: oklch(0.91 0 0);
     --grid-line: oklch(1 0 0 / 0.08);
-    --vivid: #7ee787;
-    --vivid-end: #a8f0b4;
+    --vivid: oklch(84.2% 0.1641 145.8);
+    --vivid-end: oklch(89.2% 0.1090 149.0);
     --card: oklch(38.666% 0.00004 271.152 / 0.304);
     --card-foreground: oklch(0.985 0 0 / 0.7);
     --popover: oklch(0.205 0 0);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,9 +7,13 @@
 
 body{
     background-image:
+        /* 太い罫線 */
         linear-gradient(to right,var(--grid-line) 1px,transparent 1px),
-        linear-gradient(to bottom ,var(--grid-line) 1px,transparent 1px);
-    background-size: 160px 160px;
+        linear-gradient(to bottom ,var(--grid-line) 1px,transparent 1px),
+        /* 細い罫線 */
+        linear-gradient(to right,var(--grid-subline) 1px,transparent 1px),
+        linear-gradient(to bottom ,var(--grid-subline) 1px,transparent 1px);
+    background-size: 80px 80px,80px 80px,16px 16px,16px 16px;
 }
 
 @theme inline {
@@ -58,9 +62,10 @@ body{
 }
 
 :root {
-    --background: oklch(93.7% 0.0275 90.9);
+    --background: oklch(91.599% 0.00696 88.615);
     --foreground: oklch(0.145 0 0);
     --grid-line: oklch(0 0 0 / 0.07);
+    --grid-subline: oklch(0 0 0 / 0.03);
     --vivid: oklch(50% 0.19 38);
     --vivid-end: oklch(56% 0.18 50);
     --card: rgba(255, 255, 255, 0.4);
@@ -99,6 +104,7 @@ body{
     --background: oklch(26.033% 0.00003 271.152);
     --foreground: oklch(0.91 0 0);
     --grid-line: oklch(1 0 0 / 0.08);
+    --grid-subline: oklch(1 0 0 / 0.03);
     --vivid: oklch(84.2% 0.1641 145.8);
     --vivid-end: oklch(89.2% 0.1090 149.0);
     --card: oklch(38.666% 0.00004 271.152 / 0.304);


### PR DESCRIPTION
## What
<!-- なにを変更したか -->
- SVGで指定していた`background-image`を`renear-gradient`で指定するように変更した
- その他の色を調整した
## Why
<!-- なぜ変更したか -->
- dark/lightテーマ対応にするため
- SVGのままでは`dark:`に対応できなかった。
## Chosen
<!-- なにを検討してなにを却下したか -->
- SVGの`stroke`をCSS変数で切り替えようと思ったものの、URIではCSS変数を展開できなかったため断念した。

## Log
<!-- 作業ログ 作業中のメモをここに -->

## 関連issue
closes #
