### PR TITLE
ヘッダーの再設計/実装

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@ import { Posts } from "@/components/common/PostList";
 
 const App = async () => {
     return (
-        <main className="border border-border bg-content-background">
+        <main className="bg-content-background">
             <Posts />
         </main>
     );

--- a/src/components/common/Author.tsx
+++ b/src/components/common/Author.tsx
@@ -4,7 +4,7 @@ import { CustomCard } from "./CustomCard";
 import Link from "next/link";
 export const Author = () => {
     return (
-        <CustomCard label={"Author"} className="p-2">
+        <CustomCard label={"Author"} className="p-6">
             <p className="text-sm text-foreground leading-relaxed text-left">
                 Web系ソフトウェアエンジニアを志望。
                 <br />

--- a/src/components/common/CustomCard.tsx
+++ b/src/components/common/CustomCard.tsx
@@ -4,7 +4,7 @@ import {
     CardDescription,
     CardHeader,
     CardTitle,
-} from "../ui/card";
+} from "../ui/card"; // CardConentのpaddingをリセットするため、p-0を適用している
 import { cn } from "@/lib/utils";
 
 type CardProps = {

--- a/src/components/common/CustomCard.tsx
+++ b/src/components/common/CustomCard.tsx
@@ -26,13 +26,13 @@ export const CustomCard = ({
                 className,
             )}
         >
-            <CardHeader className="">
+            <CardHeader className="gap-0">
                 <CardTitle>{title}</CardTitle>
                 <CardDescription className="absolute -top-3 px-1 z-10 bg-background text-vivid font-medium">
                     {label}
                 </CardDescription>
             </CardHeader>
-            <CardContent>{children}</CardContent>
+            <CardContent className="p-0">{children}</CardContent>
         </Card>
     );
 };

--- a/src/components/common/CustomTabs.tsx
+++ b/src/components/common/CustomTabs.tsx
@@ -6,14 +6,23 @@ import userTags from "@/user-tag.json";
 
 export const CustomTabs = ({ className }: { className?: string }) => {
     const pathName = usePathname();
-    const getLinkClass = (tabLink: string): string[] => {
+
+    const isActiveTab = (href: string): boolean => {
+        return (
+            href === pathName ||
+            (href !== "/" && pathName.startsWith(`/blog/tag/${href}`))
+        );
+    };
+
+    const getLinkClass = (href: string): string[] => {
         return [
             " bg-background flex justify-center items-center",
-            isActiveTab(tabLink)
+            isActiveTab(href)
                 ? "border border-vivid text-vivid"
                 : "bg-background/0 text-input",
         ];
     };
+
     return (
         <nav
             className={cn("flex h-auto justify-center divide-x divide-border")}
@@ -26,26 +35,18 @@ export const CustomTabs = ({ className }: { className?: string }) => {
                 {"01.HOME"}
             </Link>
             {Object.keys(userTags).map((tag, index) => {
-                const tabLink: string = `/blog/tag/${tag}`;
+                const tagHref: string = `/blog/tag/${tag}`;
                 const tabName: string = `${(index + 2).toString().padStart(2, "0")}.${tag.toUpperCase()}`;
                 return (
                     <Link
                         key={tag}
-                        href={tabLink}
-                        className={cn(getLinkClass(tag), className)}
+                        href={tagHref}
+                        className={cn(getLinkClass(tagHref), className)}
                     >
                         {tabName}
                     </Link>
                 );
             })}
         </nav>
-    );
-};
-
-const isActiveTab = (tabLink: string): boolean => {
-    const pathName = usePathname();
-    return (
-        tabLink === pathName ||
-        (tabLink !== "/" && pathName.startsWith(`/blog/tag/${tabLink}`))
     );
 };

--- a/src/components/common/CustomTabs.tsx
+++ b/src/components/common/CustomTabs.tsx
@@ -8,42 +8,34 @@ export const CustomTabs = ({ className }: { className?: string }) => {
     const pathName = usePathname();
 
     const isActiveTab = (href: string): boolean => {
-        return (
-            href === pathName ||
-            (href !== "/" && pathName.startsWith(`/blog/tag/${href}`))
-        );
+        return href === pathName || (href !== "/" && pathName.startsWith(href));
     };
 
-    const getLinkClass = (href: string): string[] => {
-        return [
-            " bg-background flex justify-center items-center",
-            isActiveTab(href)
-                ? "border border-vivid text-vivid"
-                : "bg-background/0 text-input",
-        ];
-    };
+    const tabs = [
+        { href: "/", name: "HOME" },
+        ...Object.keys(userTags).map((tag) => ({
+            href: `/blog/tag/${tag}`,
+            name: tag.toUpperCase(),
+        })),
+    ];
 
     return (
-        <nav
-            className={cn("flex h-auto justify-center divide-x divide-border")}
-        >
-            <Link
-                key={"home"}
-                href={"/"}
-                className={cn(getLinkClass("/"), className)}
-            >
-                {"01.HOME"}
-            </Link>
-            {Object.keys(userTags).map((tag, index) => {
-                const tagHref: string = `/blog/tag/${tag}`;
-                const tabName: string = `${(index + 2).toString().padStart(2, "0")}.${tag.toUpperCase()}`;
+        <nav className="flex h-auto justify-center divide-x divide-border">
+            {tabs.map((tab, index) => {
+                const label = `${(index + 1).toString().padStart(2, "0")}.${tab.name}`;
                 return (
                     <Link
-                        key={tag}
-                        href={tagHref}
-                        className={cn(getLinkClass(tagHref), className)}
+                        key={tab.href}
+                        href={tab.href}
+                        className={cn(
+                            " bg-background flex justify-center items-center",
+                            isActiveTab(tab.href)
+                                ? "border border-vivid text-vivid"
+                                : "bg-background/0 text-input",
+                            className,
+                        )}
                     >
-                        {tabName}
+                        {label}
                     </Link>
                 );
             })}

--- a/src/components/common/CustomTabs.tsx
+++ b/src/components/common/CustomTabs.tsx
@@ -15,10 +15,13 @@ export type NonEmptyArray<T> = [T, ...T[]];
 export const CustomTabs = ({ tabs, className }: Params) => {
     const pathName = usePathname();
     return (
-        <nav className={cn("flex h-auto justify-center divide-x divide-border")}>
+        <nav
+            className={cn("flex h-auto justify-center divide-x divide-border")}
+        >
             {tabs.map((tab) => {
                 const isActive =
-                    tab.link === pathName || (tab.link !== "/" && pathName.startsWith(tab.link));
+                    tab.link === pathName ||
+                    (tab.link !== "/" && pathName.startsWith(tab.link));
                 return (
                     <Link
                         key={tab.name}
@@ -26,7 +29,7 @@ export const CustomTabs = ({ tabs, className }: Params) => {
                         className={cn(
                             " bg-background flex justify-center items-center",
                             isActive
-                                ? "bg-foreground text-background"
+                                ? "border border-vivid text-vivid"
                                 : "bg-background/0 text-input",
                             className,
                         )}

--- a/src/components/common/CustomTabs.tsx
+++ b/src/components/common/CustomTabs.tsx
@@ -4,41 +4,48 @@ import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import userTags from "@/user-tag.json";
 
-export type TabProp = {
-    name: string;
-    link: string;
-};
-
-type Params = { tabs: NonEmptyArray<TabProp> } & { className?: string };
-
-export type NonEmptyArray<T> = [T, ...T[]];
-
-export const CustomTabs = ({ tabs, className }: Params) => {
+export const CustomTabs = ({ className }: { className?: string }) => {
     const pathName = usePathname();
+    const getLinkClass = (tabLink: string): string[] => {
+        return [
+            " bg-background flex justify-center items-center",
+            isActiveTab(tabLink)
+                ? "border border-vivid text-vivid"
+                : "bg-background/0 text-input",
+        ];
+    };
     return (
         <nav
             className={cn("flex h-auto justify-center divide-x divide-border")}
         >
-            {tabs.map((tab) => {
-                const isActive =
-                    tab.link === pathName ||
-                    (tab.link !== "/" && pathName.startsWith(tab.link));
-                const linkClass: string[] = [
-                    " bg-background flex justify-center items-center",
-                    isActive
-                        ? "border border-vivid text-vivid"
-                        : "bg-background/0 text-input",
-                ];
+            <Link
+                key={"home"}
+                href={"/"}
+                className={cn(getLinkClass("/"), className)}
+            >
+                {"01.HOME"}
+            </Link>
+            {Object.keys(userTags).map((tag, index) => {
+                const tabLink: string = `/blog/tag/${tag}`;
+                const tabName: string = `${(index + 2).toString().padStart(2, "0")}.${tag.toUpperCase()}`;
                 return (
                     <Link
-                        key={"home"}
-                        href={"/"}
-                        className={cn(linkClass, className)}
+                        key={tag}
+                        href={tabLink}
+                        className={cn(getLinkClass(tag), className)}
                     >
-                        {"01.HOME"}
+                        {tabName}
                     </Link>
                 );
             })}
         </nav>
+    );
+};
+
+const isActiveTab = (tabLink: string): boolean => {
+    const pathName = usePathname();
+    return (
+        tabLink === pathName ||
+        (tabLink !== "/" && pathName.startsWith(`/blog/tag/${tabLink}`))
     );
 };

--- a/src/components/common/CustomTabs.tsx
+++ b/src/components/common/CustomTabs.tsx
@@ -2,6 +2,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
+import userTags from "@/user-tag.json";
 
 export type TabProp = {
     name: string;
@@ -22,19 +23,19 @@ export const CustomTabs = ({ tabs, className }: Params) => {
                 const isActive =
                     tab.link === pathName ||
                     (tab.link !== "/" && pathName.startsWith(tab.link));
+                const linkClass: string[] = [
+                    " bg-background flex justify-center items-center",
+                    isActive
+                        ? "border border-vivid text-vivid"
+                        : "bg-background/0 text-input",
+                ];
                 return (
                     <Link
-                        key={tab.name}
-                        href={tab.link}
-                        className={cn(
-                            " bg-background flex justify-center items-center",
-                            isActive
-                                ? "border border-vivid text-vivid"
-                                : "bg-background/0 text-input",
-                            className,
-                        )}
+                        key={"home"}
+                        href={"/"}
+                        className={cn(linkClass, className)}
                     >
-                        {tab.name}
+                        {"01.HOME"}
                     </Link>
                 );
             })}

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -7,6 +7,7 @@ import {
     type TabProp,
     NonEmptyArray,
 } from "@/components/common/CustomTabs";
+import { CustomCard } from "./CustomCard";
 const tabProps: NonEmptyArray<TabProp> = [
     {
         name: "01.HOME",
@@ -25,35 +26,42 @@ const tabSize = "size-25";
 
 export const Header = () => {
     return (
-        <header className="col-span-2 flex items-center border border-border divide-x divide-border bg-content-background text-input">
-            <Link
-                href="/"
-                aria-label="トップページへ戻る"
-                className="flex-1 flex p-4 h-full"
+        <header className="col-span-2 flex items-center justify-between border border-border bg-content-background text-input h-25 ">
+            <CustomCard
+                label="Top"
+                className="h-full w-auto p-0 m-0 border-transparent"
             >
-                <Image
-                    src={localImage}
-                    alt="プロフィール画像"
-                    height={64}
-                    width={64}
-                    className="mr-4 rounded-full object-cover"
-                />
-                <div className="text-border">
-                    <p>Personal Log</p>
-                    <div className="flex items-end gap-2">
-                        <h1 className="text-foreground text-3xl font-bold">
-                            DEV活
-                        </h1>
-                        <p>RyoK73@omarchy</p>
+                <Link
+                    href="/"
+                    aria-label="トップページへ戻る"
+                    className="flex h-full border border-transparent m-2"
+                >
+                    <Image
+                        src={localImage}
+                        alt="プロフィール画像"
+                        height={64}
+                        width={64}
+                        className="w-auto mr-4 rounded-full object-cover"
+                    />
+                    <div className="text-border flex flex-col justify-center text-[1rem]">
+                        <p>Personal Log</p>
+                        <div className="flex items-end gap-2">
+                            <h1 className="text-foreground text-3xl font-bold text-nowrap">
+                                DEV活
+                            </h1>
+                            <p>RyoK73@omarchy</p>
+                        </div>
                     </div>
+                </Link>
+            </CustomCard>
+            <div className="flex divide-x divide-border border-l">
+                <div className="flex h-full justify-end">
+                    <CustomTabs tabs={tabProps} className={tabSize} />
                 </div>
-            </Link>
-            <div className="flex h-full justify-end">
-                <CustomTabs tabs={tabProps} className={tabSize} />
+                <SwitchTheme
+                    className={`flex justify-center items-center ${tabSize}`}
+                />
             </div>
-            <SwitchTheme
-                className={`flex justify-center items-center ${tabSize}`}
-            />
         </header>
     );
 };

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -36,10 +36,8 @@ export const Header = () => {
                     </div>
                 </Link>
             </CustomCard>
-            <div className="flex divide-x divide-border border-l">
-                <div className="flex h-full justify-end">
-                    <CustomTabs className={tabSize} />
-                </div>
+            <div className="flex divide-x divide-border border-l justify-end">
+                <CustomTabs className={tabSize} />
                 <SwitchTheme
                     className={`flex justify-center items-center text-vivid ${tabSize}`}
                 />

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -59,7 +59,7 @@ export const Header = () => {
                     <CustomTabs tabs={tabProps} className={tabSize} />
                 </div>
                 <SwitchTheme
-                    className={`flex justify-center items-center ${tabSize}`}
+                    className={`flex justify-center items-center text-vivid ${tabSize}`}
                 />
             </div>
         </header>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -2,26 +2,8 @@ import Image from "next/image";
 import Link from "next/link";
 import localImage from "../../../public/topImage.png";
 import { SwitchTheme } from "@/components/common/SwitchTheme";
-import {
-    CustomTabs,
-    type TabProp,
-    NonEmptyArray,
-} from "@/components/common/CustomTabs";
+import { CustomTabs } from "@/components/common/CustomTabs";
 import { CustomCard } from "./CustomCard";
-const tabProps: NonEmptyArray<TabProp> = [
-    {
-        name: "01.HOME",
-        link: "/",
-    },
-    {
-        name: "02.WORK",
-        link: "/blog/tag/works",
-    },
-    {
-        name: "03.ABOUT",
-        link: "/about",
-    },
-];
 const tabSize = "size-25";
 
 export const Header = () => {
@@ -56,7 +38,7 @@ export const Header = () => {
             </CustomCard>
             <div className="flex divide-x divide-border border-l">
                 <div className="flex h-full justify-end">
-                    <CustomTabs tabs={tabProps} className={tabSize} />
+                    <CustomTabs className={tabSize} />
                 </div>
                 <SwitchTheme
                     className={`flex justify-center items-center text-vivid ${tabSize}`}


### PR DESCRIPTION
- **chore:shadcn/uiのgap,paddingを0に設定**
- **fix:borderが2重に適用されるバグの修正**
- **feat:Headerの構成を変更**
- **feat:選択時のスタイルを変更**
- **chore:カード内のpaddingを2→6に増加**
- **chore:テーマ切り替えボタンのtext-coloerをvividに変更**
- **feat:user-tag.jsonからのタブ動的生成機能を実装**

## What/Why
<!--
### なにを変更したか
- なぜ変更したか
-->
## ブログアイコン・タイトルをCustomCardで再構築
- 以前のLink構成ではタブ以外のHeader全体がトップページへの遷移アクセスとなっていたため範囲を制限するため
- "Top"と表示されてるようなフロー表示を適用し、ブログ全体のスタイルに一貫性を持たせるため
## user-tag.jsonからタブを動的に生成する機能を実装
- ブログ記事のtagと連動させるため
- さらに、HOME:"/"とuser-tagを組み合わせたtabs配列を追加し、tabs.map()でタブをレンダリングするよう変更

## タブアクティブ時/テーマ切り替えボタンのスタイルをvividに統一
- ブログ全体のカラーテーマに一貫性を持たせるため



## Chosen
<!--
### なにを検討したか
- なにを却下したか
-->
###

## 関連issue
closes #52
closes #40
