### PR TITLE
fix: CodeBlockのコードが長い場合にmax-w-6xlを超えるバグを修正

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -178,6 +178,9 @@ body {
         code:not(pre code)::after {
             content: "";
         }
+        pre {
+            @apply whitespace-pre-wrap break-all;
+        }
     }
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -179,7 +179,7 @@ body {
             content: "";
         }
         pre {
-            @apply whitespace-pre-wrap break-all;
+            @apply whitespace-pre-wrap wrap-break-word;
         }
     }
 }

--- a/src/components/common/CodeBlock.tsx
+++ b/src/components/common/CodeBlock.tsx
@@ -28,9 +28,12 @@ export const CodeBlock = async ({ children }: CodeProps) => {
 
     return (
         <div className="relative">
-            <div className="" dangerouslySetInnerHTML={{ __html: html }} />
+            <div
+                className="overflow-x-auto"
+                dangerouslySetInnerHTML={{ __html: html }}
+            />
             <CopyButton
-                className="absolute top-5 right-5 duration-300"
+                className="absolute top-10 right-5 duration-300"
                 code={code}
             />
         </div>


### PR DESCRIPTION
## 概要

`react-markdown` + shiki のコードブロックに極端に長い1行が含まれる場合、ページ全体が `max-w-6xl` を無視して横方向にはみ出すバグを修正する。

## 背景・動機

記事 `react-markdown-codeblock-by-shiki` を表示すると、consola のデバッグ出力を示すコードブロックに `\n` をリテラルとして含む極めて長い1行が存在し、`pre` 要素が `white-space: pre` により無制限に横へ広がっていた。`max-w-6xl` コンテナに `overflow` 制御がないため、ページレベルで横スクロールバーが発生していた。

## 変更内容

- **`src/components/common/CodeBlock.tsx`**: shiki HTML を内包する div に `overflow-x-auto` を追加（横スクロールコンテナ化）
- **`src/components/common/CodeBlock.tsx`**: CopyButton の縦位置を `top-5` → `top-10` に調整（折り返し対応後の位置ズレ修正）
- **`src/app/globals.css`**: `.prose pre` に `whitespace-pre-wrap wrap-break-word` を追加（単語単位での折り返しを有効化）

## 設計判断・補足

`overflow-x-auto` のみでは解決せず、`whitespace-pre-wrap` による折り返しが根本解決となった。`overflow-x-auto` は保険として残している。

折り返しには `break-all`（文字単位）ではなく `wrap-break-word`（単語単位）を採用し、識別子・文字列が途中で切れることを防いでいる。

## レビュー観点メモ

- **セキュリティ**: `dangerouslySetInnerHTML` は shiki の出力（著者制御の静的コンテンツ）のみに使用。問題なし
- **可読性・保守性**: `.prose pre` への変更は全記事のコードブロックに影響する。`wrap-break-word` は単語単位のため視認性を損なわない
- **パフォーマンス**: CSS 追加のみ。影響なし
- **影響範囲**: 全記事の `.prose pre` に折り返しが適用される。既存表示への破壊的影響はないが、長い行を持つ他記事でも折り返しが発生する
- **エラーハンドリング**: `children.type !== "code"` のフォールバック `<pre>` は globals.css の `whitespace-pre-wrap` のみが効く。軽微のため許容

## テスト方法

1. `/blog/tech/react-markdown-codeblock-by-shiki` にアクセス
2. ページに水平スクロールバーが出ないことを確認
3. コードブロックが単語単位で折り返されることを確認
4. コピーボタンがコードブロック右上に正しく表示されることを確認
5. 他のコードブロックを含む記事で表示崩れがないことを確認

## 未対応・既知の問題

特になし