### PR TITLE
fix: sitemap.ts起因のビルドエラーを修正

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,6 @@
 import type { NextConfig } from "next";
 
+// ローカルビルド時はNEXT_PUBLIC_SITE_URL="http://localhost:3000"を.envに追加する
 if (
   !process.env.NEXT_PUBLIC_SITE_URL &&
   process.env.NODE_ENV === "production"
@@ -7,8 +8,6 @@ if (
   throw new Error("NEXT_PUBLIC_SITE_URL is required in production");
 }
 
-const nextConfig: NextConfig = {
-  /* config options here */
-};
+const nextConfig: NextConfig = {/* config options here */};
 
 export default nextConfig;

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,6 +1,6 @@
 import { MetadataRoute } from "next";
 
-export const robots = (): MetadataRoute.Robots => {
+export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
       userAgent: "*",
@@ -8,6 +8,4 @@ export const robots = (): MetadataRoute.Robots => {
     },
     sitemap: `${process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000"}/sitemap.xml`,
   };
-};
-
-export default robots;
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -4,7 +4,7 @@ import userCategory from "@/user-category.json";
 
 const categories = Object.keys(userCategory);
 
-export const sitemap = async (): Promise<MetadataRoute.Sitemap> => {
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000";
 
   // 記事一覧を取得
@@ -28,6 +28,4 @@ export const sitemap = async (): Promise<MetadataRoute.Sitemap> => {
     ...categoryEntries,
     ...postEntries,
   ];
-};
-
-export default sitemap;
+}


### PR DESCRIPTION
## 概要

Next.jsビルド時に発生していた `Error: Default export is missing in "./sitemap.ts"` を修正する。`sitemap.ts` / `robots.ts` のexport形式を、Next.jsが正しく認識できる関数宣言＋直接default exportの形式に統一した。

## 背景・動機

- ビルド実行時に `Default export is missing in "./sitemap.ts"` エラーが発生していた
- Issue #95: Google Search Consoleから「sitemapに3ページしか反映されていないが、実際には未反映の複数ページがある」旨のメールを受信。export defaultが正しく機能していなかったことが一因の可能性がある

## 変更内容

- `src/app/sitemap.ts`: `export const sitemap = async (): ... => {...}` + 別出しの `export default sitemap;` を `export default async function sitemap(): ...` に変更
- `src/app/robots.ts`: 同様に `export const robots = (): ... => {...}` + 別出しの `export default robots;` を `export default function robots(): ...` に変更
- `next.config.ts`: ローカルビルド時に `NEXT_PUBLIC_SITE_URL` を `.env` に追加する必要がある旨のコメントを追加

## 設計判断・補足

ロジック自体（返却するsitemap/robotsの中身）には一切手を加えず、Next.jsの特殊ファイルとして正しく認識されるexportの記法統一のみに変更を限定した。これにより影響範囲を最小限に抑えている。

## レビュー観点メモ

- **セキュリティ**: 該当なし
- **可読性・保守性**: `next.config.ts` の `nextConfig` オブジェクト定義部で、オートフォーマッタにより意図せず改行が削除されている（`const nextConfig: NextConfig = {/* config options here */};` の1行化）。フォーマット設定の見直しを推奨
- **パフォーマンス**: 該当なし（ロジック変更なし）
- **影響範囲**: `sitemap` / `robots` のnamed exportを他ファイルから参照している箇所がないことを確認済み。破壊的変更の心配なし
- **エラーハンドリング**: 該当なし

## 未対応・既知の問題

- Issue #95（Search Consoleでのページ反映漏れ）が本修正で解消するかは未検証。本ブランチでリリース後、Search Consoleの反映状況を経過観察する予定